### PR TITLE
🐛: 修复全局参数使用|分割值的问题

### DIFF
--- a/src/main/java/org/cloud/sonic/simple/services/impl/TestSuitesServiceImpl.java
+++ b/src/main/java/org/cloud/sonic/simple/services/impl/TestSuitesServiceImpl.java
@@ -92,7 +92,7 @@ public class TestSuitesServiceImpl extends SonicServiceImpl<TestSuitesMapper, Te
         JSONObject gp = new JSONObject();
         for (GlobalParams g : globalParamsList) {
             if (g.getParamsValue().contains("|")) {
-                List<String> shuffle = Arrays.asList(g.getParamsValue().split("|"));
+                List<String> shuffle = Arrays.asList(g.getParamsValue().split("\\|"));
                 Collections.shuffle(shuffle);
                 valueMap.put(g.getParamsKey(), shuffle);
             } else {


### PR DESCRIPTION
之前漏了转义。
这个功能我用得少，不确定有没有啥隐藏逻辑，可以再check下。