### PR TITLE
🐛: 修复测试详情页为空时报错的问题

### DIFF
--- a/src/main/java/org/cloud/sonic/simple/services/impl/TestCasesServiceImpl.java
+++ b/src/main/java/org/cloud/sonic/simple/services/impl/TestCasesServiceImpl.java
@@ -131,6 +131,9 @@ public class TestCasesServiceImpl extends SonicServiceImpl<TestCasesMapper, Test
 
     @Override
     public List<TestCases> findByIdIn(List<Integer> ids) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return new ArrayList<>();
+        }
         return listByIds(ids);
     }
 


### PR DESCRIPTION
https://github.com/SonicCloudOrg/sonic-client-web/issues/97