### PR TITLE
🐛: 修复条件步骤的子步骤中含有公共步骤时，普通步骤丢失的问题

### DIFF
--- a/src/main/java/org/cloud/sonic/simple/models/dto/StepsDTO.java
+++ b/src/main/java/org/cloud/sonic/simple/models/dto/StepsDTO.java
@@ -2,15 +2,13 @@ package org.cloud.sonic.simple.models.dto;
 
 
 import com.alibaba.fastjson.annotation.JSONField;
-import com.baomidou.mybatisplus.annotation.TableField;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.gitee.sunchenbin.mybatis.actable.annotation.Column;
-import lombok.*;
-import org.cloud.sonic.simple.models.base.TypeConverter;
-import org.cloud.sonic.simple.models.domain.Steps;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
 import lombok.experimental.Accessors;
+import org.cloud.sonic.simple.models.base.TypeConverter;
+import org.cloud.sonic.simple.models.domain.Steps;
 import org.cloud.sonic.simple.models.enums.ConditionEnum;
 
 import javax.validation.constraints.NotBlank;
@@ -68,7 +66,7 @@ public class StepsDTO implements Serializable, TypeConverter<StepsDTO, Steps> {
      * @see ConditionEnum
      */
     @ApiModelProperty(value = "步骤条件类型，0：非条件  1：if  2：else if  3：else  4：while", example = "0")
-    private Integer conditionType = 0;
+    private Integer conditionType;
 
     @ApiModelProperty(value = "包含元素列表")
     List<ElementsDTO> elements;

--- a/src/main/java/org/cloud/sonic/simple/services/impl/TestSuitesServiceImpl.java
+++ b/src/main/java/org/cloud/sonic/simple/services/impl/TestSuitesServiceImpl.java
@@ -332,7 +332,7 @@ public class TestSuitesServiceImpl extends SonicServiceImpl<TestSuitesMapper, Te
             }
         }
 
-        List<JSONObject> childStepJsonObjs = new ArrayList<>();
+        JSONArray childStepJsonObjs = new JSONArray();
         JSONObject stepsJsonObj = JSON.parseObject(JSON.toJSONString(steps));
 
         // 如果是条件步骤则遍历子步骤
@@ -353,11 +353,14 @@ public class TestSuitesServiceImpl extends SonicServiceImpl<TestSuitesMapper, Te
                                 put("step", stepsService.handleStep(childStep));
                             }
                         };
+                        // 添加转换后的公共步骤
                         childStepJsonObjs.add(childStepJsonObj);
                     }
-                    // 改写子步骤为公共步骤
-                    stepsJsonObj.put("childSteps", childStepJsonObjs);
+                } else {
+                    // 如果不是公共步骤，则直接添加
+                    childStepJsonObjs.add(childStep);
                 }
+                stepsJsonObj.put("childSteps", childStepJsonObjs);
             }
             step.put("step", stepsJsonObj);
             return step;


### PR DESCRIPTION
旧的用例都回归过了